### PR TITLE
fixed wrong "null" variable

### DIFF
--- a/FixUnquotedPaths.ps1
+++ b/FixUnquotedPaths.ps1
@@ -30,7 +30,7 @@ $ServiceItems = $result | Foreach-Object {Get-ItemProperty $_.PsPath}
 
 # Iterate through the keys and check for Unquoted ImagePath's
 ForEach ($si in $ServiceItems) {
-	if ($si.ImagePath -ne $nul) { 
+	if ($null -ne $si.ImagePath) { 
 		$obj = New-Object -Typename PSObject
 		$obj | Add-Member -MemberType NoteProperty -Name Status -Value "Retrieved"
 		# There is certianly a way to use the full path here but for now I trim it until I can find time to play with it


### PR DESCRIPTION
Hi there,

I've just seen the typo of `$nul` compared to `$null`.
I guess there was no issue with this at all, because the Empty `$nul` is equal to `$null`.

Also i've changed the order of the check, because of VSCode Recomondations:
`$null should be on the left side of equality comparisons.PSScriptAnalyzer(PSPossibleIncorrectComparisonWithNull)`

kind regards
Daniel
